### PR TITLE
chore: Fix pipx permissions on macOS arm64 in CI

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -40,13 +40,17 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
           check-latest: true
-      # pipx is not installed by default on macOS 14 arm64 runners
+      # pipx currently has permissions issues on macOS 14 arm64 runners
       # see https://github.com/actions/runner-images/issues/9256
-      - name: Install pipx
+      - name: Fix pipx permissions
         if: matrix.runner == 'macos-14'
         run: |
-          pip install pipx
-          echo PATH="$(pipx environment -V PIPX_BIN_DIR):$PATH" >> $GITHUB_ENV
+          for dir in "$PIPX_HOME" "$PIPX_BIN_DIR"; do
+            if [ -n "$dir" ]; then
+              sudo mkdir -p "$dir"
+              sudo chown -R $(id -u) "$dir"
+            fi
+          done
       - name: Test
         run: pipx run hatch run dev:test
         working-directory: bindings/python


### PR DESCRIPTION
Thanks to our scheduled workflow, we have detected a CI breakage on macOS arm64 runners in the current image which recently added `pipx` but in a broken way. This is a workaround to fix the broken `pipx` installation. Once resolved in the runner image, we'll be able to get rid of this.

See https://github.com/actions/runner-images/issues/9256 for more details, and specifically this comment: https://github.com/actions/runner-images/issues/9256#issuecomment-2028295770.