### PR TITLE
chore: Remove temporary fix for pipx permissions on Apple Silicon runners

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -42,17 +42,6 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
           check-latest: true
-      # pipx currently has permissions issues on macOS 14 arm64 runners
-      # see https://github.com/actions/runner-images/issues/9256
-      - name: Fix pipx permissions
-        if: matrix.runner == 'macos-14'
-        run: |
-          for dir in "$PIPX_HOME" "$PIPX_BIN_DIR"; do
-            if [ -n "$dir" ]; then
-              sudo mkdir -p "$dir"
-              sudo chown -R $(id -u) "$dir"
-            fi
-          done
       - name: Test
         run: pipx run --python '${{ steps.setup-python.outputs.python-path }}' hatch run dev:test
         working-directory: bindings/python


### PR DESCRIPTION
Now that https://github.com/actions/runner-images/issues/9256 has been fixed, our workaround is no longer required.