### PR TITLE
Add nudge workflow

### DIFF
--- a/.github/workflows/nudge.yml
+++ b/.github/workflows/nudge.yml
@@ -1,0 +1,17 @@
+name: Nudge
+
+on:
+  workflow_run:
+    workflows: ["CI", "Create release"]
+    types: [completed]
+    branches: [main]
+
+jobs:
+  nudge:
+    runs-on: ubuntu-latest
+    environment: nudge
+    steps:
+      - name: Send message
+        uses: pavlovic-ivan/octo-nudge@main
+        with:
+          webhooks: ${{ secrets.WEBHOOKS }}


### PR DESCRIPTION
This PR adds a workflow called Nudge. This will call the octo-nudge action when a CI is completed, no matter if it fails or succeeds, and send a message to Slack channel using a webhook. 

Before merging the PR:
- [x] create an environment called `nudge` for the `main` branch
- [x] add a secret called `WEBHOOKS`