### PR TITLE
[Python Bindings] Add option to update T-Digest from buffer

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,17 @@ digest2 = TDigest.from_array(arr=arr2)
 merged_digest = digest1.merge(digest2, delta=100.0)  # delta again defaults to 300.0
 ```
 
+### Updating TDigests
+
+```python
+arr = np.random.randn(1000)
+digest = TDigest.from_array(arr=arr1)
+
+# Buffer data points before updating
+buffer = np.random.randn(1)
+digest = digest.update(buffer, delta=300.0, merge_delta=100.0)
+```
+
 ### Serialising TDigests
 
 The ``TDigest`` object can be converted to a dictionary and JSON-serialised and is also pickleable.

--- a/bindings/python/tdigest_rs/lib.py
+++ b/bindings/python/tdigest_rs/lib.py
@@ -93,3 +93,9 @@ class TDigest:
                 return _TDigestInternal64
             case _:
                 raise TypeError(f"TDigest is not implemented for arr with type {arr.dtype}")
+
+    def update(
+        self, buffer: npt.NDArray[np.float32], delta: float = DEFAULT_DELTA, merge_delta: float = DEFAULT_DELTA
+    ) -> "TDigest":
+        buffer_digest = TDigest.from_array(buffer, delta)
+        return self.merge(buffer_digest, merge_delta)


### PR DESCRIPTION
Fixes #18 

### Proposed Changes

The PR proposes the following changes:

1. Add a method `update` to update the T-Digest using a buffer of data points where the caller is responsible for buffering the data points.
2. Add a section with example to update the tdigest with a buffer

### Checklist

- [x] Run linters
- [x] Run tests
- [x] Run benchmark
- [x] Format code