### PR TITLE
security: pin GitHub Actions references to commit SHAs

### DIFF
--- a/.github/workflows/check-required.yml
+++ b/.github/workflows/check-required.yml
@@ -27,12 +27,12 @@ jobs:
     steps:
       - name: Generate an app token
         id: app-token
-        uses: actions/create-github-app-token@v1
+        uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547
         with:
           app-id: ${{ secrets.APP_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
 
-      - uses: actions/github-script@v7
+      - uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b
         with:
           github-token: ${{ steps.app-token.outputs.token }}
           script: |

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -16,7 +16,7 @@ jobs:
       # Regex comes from https://semver.org/#is-there-a-suggested-regular-expression-regex-to-check-a-semver-string
       - name: Check version
         id: version
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b
         with:
           script: |
             const semver = /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$/;
@@ -30,13 +30,13 @@ jobs:
 
       - name: Generate an app token
         id: app-token
-        uses: actions/create-github-app-token@v1
+        uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547
         with:
           app-id: ${{ secrets.APP_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
 
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
           token: ${{ steps.app-token.outputs.token }}
           fetch-depth: 0

--- a/.github/workflows/nudge.yml
+++ b/.github/workflows/nudge.yml
@@ -12,6 +12,6 @@ jobs:
     environment: nudge
     steps:
       - name: Send message
-        uses: pavlovic-ivan/octo-nudge@main
+        uses: pavlovic-ivan/octo-nudge@ff46467a3892a7b98b103508ebbd1e9ba7b364b1
         with:
           webhooks: ${{ secrets.WEBHOOKS }}

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -15,9 +15,9 @@ jobs:
     name: Lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
       - name: Set up Python ${{ env.DEFAULT_PYTHON_VERSION }}
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
         id: setup-python
         with:
           python-version: ${{ env.DEFAULT_PYTHON_VERSION }}
@@ -35,9 +35,9 @@ jobs:
       fail-fast: false
     runs-on: ${{ matrix.runner }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
         id: setup-python
         with:
           python-version: ${{ matrix.python-version }}
@@ -68,9 +68,9 @@ jobs:
       fail-fast: false
     runs-on: ${{ matrix.runner }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
       - name: Build
-        uses: PyO3/maturin-action@v1
+        uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b
         with:
           command: build
           args: --release
@@ -78,7 +78,7 @@ jobs:
           target: ${{ matrix.target }}
           working-directory: bindings/python
       - name: Upload Python Package
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
         with:
           name: python-package-${{ matrix.target }}
           path: target/wheels/*.whl

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,13 +15,13 @@ jobs:
       id-token: write
     steps:
       - name: Download artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
         with:
           pattern: python-package-*
           merge-multiple: true
           path: dist
       - name: Publish package distributions to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b
 
   github-release:
     name: Publish GitHub release
@@ -31,14 +31,14 @@ jobs:
       contents: write
     steps:
       - name: Download artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
         with:
           pattern: python-package-*
           merge-multiple: true
           path: dist
 
       - name: Create release
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@de2c0eb89ae2a093876385947365aca7b0e5f844
         with:
           generate_release_notes: true
           files: dist/*

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -14,7 +14,7 @@ jobs:
     name: Lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
       - name: Clippy
         run: cargo clippy --verbose
       - name: Format check
@@ -29,6 +29,6 @@ jobs:
       fail-fast: false
     runs-on: ${{ matrix.runner }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
       - name: Run tests
         run: cargo test --verbose


### PR DESCRIPTION
## Summary

Pins all GitHub Actions references in this repo to 40-character commit SHAs, replacing tag and branch references. This is a supply-chain hardening change with no expected functional impact — every SHA was resolved from its current tag/branch at audit time (2026-05-27).

## Why

Tag-pinned actions can be silently compromised if the upstream tag is rotated to a malicious commit. Branch-pinned actions (e.g. `@main`, `@release/v1`, `@stable`) are even riskier — anyone with push access upstream can change what runs in CI.

GitHub's own recommendation: https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-third-party-actions

## Notes

- Branch-pinned refs (`@main`, `@release/v1`, `@stable`) were resolved to the branch HEAD at audit time — re-verify before merge if the upstream branch has moved since.
- Part of an org-wide audit covering 26 G-Research repos. The full pinning plan and resolved SHAs are tracked in a local audit project.
- No functional change is expected; CI should pass identically.