### PR TITLE
ci: migrate macos-13 runner label to macos-15-intel

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -31,7 +31,7 @@ jobs:
     strategy:
       matrix:
         python-version: ["3.10", "3.11", "3.12"]
-        runner: [ubuntu-latest, macos-13, macos-14, windows-latest]
+        runner: [ubuntu-latest, macos-15-intel, macos-14, windows-latest]
       fail-fast: false
     runs-on: ${{ matrix.runner }}
     steps:
@@ -59,7 +59,7 @@ jobs:
             target: aarch64-unknown-linux-musl
           - runner: ubuntu-latest
             target: x86_64-unknown-linux-musl
-          - runner: macos-13
+          - runner: macos-15-intel
             target: x86_64-apple-darwin
           - runner: macos-14
             target: aarch64-apple-darwin

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -24,8 +24,8 @@ jobs:
     name: Test
     strategy:
       matrix:
-        # macos-13 is x86_64 and macos-14 is arm64
-        runner: [ubuntu-latest, macos-13, macos-14, windows-latest]
+        # macos-15-intel is x86_64 and macos-14 is arm64
+        runner: [ubuntu-latest, macos-15-intel, macos-14, windows-latest]
       fail-fast: false
     runs-on: ${{ matrix.runner }}
     steps:


### PR DESCRIPTION
## Summary

Migrates the `macos-13` runner label to `macos-15-intel` in our CI matrices. The `macos-13` images were retired by GitHub on **2025-12-08** (deprecation announced [2025-09-19](https://github.blog/changelog/2025-09-19-github-actions-macos-13-runner-image-is-closing-down/)) and are no longer being picked up by any runner — jobs targeting `macos-13` sit in `queued` indefinitely and block any required-status-check policy on `main`.

`macos-15-intel` is the GitHub-recommended replacement label for x86_64 macOS coverage. We keep `macos-14` for arm64.

## Why now

#41 (the SHA-pinning PR) is approved but cannot merge — its `Test (macos-13)` and `Build (macos-13, x86_64-apple-darwin)` jobs are stuck in `queued` forever and the base-branch protection won't let it through.

Merging this PR first, then rebasing #41, unblocks it without needing admin-bypass.

## Files changed

- `.github/workflows/rust.yml` — test matrix: `macos-13` → `macos-15-intel`
- `.github/workflows/python.yml` — test matrix + build include: `macos-13` → `macos-15-intel`

## Notes

- No source changes; CI-only.
- x86_64 macOS support on hosted runners is itself sunsetting in Fall 2027 ([reference](https://docs.github.com/en/actions/reference/runners/github-hosted-runners)); a follow-up may want to drop the Intel matrix row entirely at that point.
